### PR TITLE
ci: teste gegen aktuelle Home Assistant Version

### DIFF
--- a/.github/scripts/update_requirements.py
+++ b/.github/scripts/update_requirements.py
@@ -245,6 +245,7 @@ def process_requirements_file(
 
         if base_pkg in PYTEST_HA_DEPENDENT_PACKAGES and base_pkg in pytest_ha_reqs:
             target_version = pytest_ha_reqs[base_pkg]
+            target_source = "from pytest-homeassistant-custom-component GitHub repo"
 
             if base_pkg == 'homeassistant' and is_homeassistant_beta(target_version):
                 updated_lines.append(line)
@@ -259,7 +260,7 @@ def process_requirements_file(
                     updated_lines.append(new_line)
                     file_changed = True
                     changes.append(
-                        f"{path}: {req.package} {req.operator}{req.version} -> {req.operator}{target_version} (from pytest-homeassistant-custom-component GitHub repo)"
+                        f"{path}: {req.package} {req.operator}{req.version} -> {req.operator}{target_version} ({target_source})"
                     )
                 else:
                     updated_lines.append(line)
@@ -453,5 +454,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
-

--- a/.github/workflows/post-merge-ha-test.yml
+++ b/.github/workflows/post-merge-ha-test.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 3 * * 5' # Freitags 03:00 UTC (05:00 CET)
+    - cron: '0 4 * * 5' # Freitags 04:00 UTC (05:00 CEST)
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,7 +29,21 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "schedule" ]; then
+            HOUR=$(TZ=Europe/Berlin date +'%H')
+            if [ "$HOUR" != "05" ]; then
+              echo "test_needed=false" >> "${GITHUB_OUTPUT}"
+              echo "Zeitgesteuerte Ausführung außerhalb 05:00 Europe/Berlin - Test wird übersprungen"
+              exit 0
+            fi
+            echo "test_needed=true" >> "${GITHUB_OUTPUT}"
+            echo "Zeitgesteuerte Ausführung um 05:00 Europe/Berlin - HA-Test wird ausgeführt"
+            exit 0
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "test_needed=true" >> "${GITHUB_OUTPUT}"
+            echo "Manuelle Ausführung - HA-Test wird ausgeführt"
+            exit 0
+          elif [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
             BASE_BRANCH="${GITHUB_BASE_REF}"
             git fetch origin "${BASE_BRANCH}" --depth=1
             DIFF_BASE="origin/${BASE_BRANCH}"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Ausfallsichere Median-Werte für verschiedene Orte, berechnet aus mehreren Stati
 ## Was brauchen wir?
 
 - Python 3.13.2 oder neuer
-- Home Assistant (Version 2026.4.1 oder neuer)
+- Home Assistant (Version 2026.4.3 oder neuer)
 - HACS (Home Assistant Community Store) - für die einfache Installation
 - Internetverbindung
 
@@ -114,7 +114,7 @@ logger:
 
 ## Updates
 
-- **Automatisch**: HACS zeigt Updates an. Zusätzlich halten GitHub Actions die Abhängigkeiten wöchentlich aktuell (Patch/Minor) und erstellen PRs. Dependabot aktualisiert GitHub Actions-Versionen automatisch. Die Integration wird durch die Automatisierung eigenständig gepflegt und führt erfolgreiche Abhängigkeits-PRs nach bestandenem CI- und HA-Kompatibilitätscheck automatisch zusammen. Zuletzt erfolgreich getestet mit Home Assistant 2026.4.1.
+- **Automatisch**: HACS zeigt Updates an. Zusätzlich halten GitHub Actions die Abhängigkeiten wöchentlich aktuell (Patch/Minor) und erstellen PRs. Dependabot aktualisiert GitHub Actions-Versionen automatisch. Die Integration wird durch die Automatisierung eigenständig gepflegt und führt erfolgreiche Abhängigkeits-PRs nach bestandenem CI- und HA-Kompatibilitätscheck automatisch zusammen. Zuletzt erfolgreich getestet mit Home Assistant 2026.4.3.
 - **Manuell**: Neue Version herunterladen.
 
 ## Unterstützung

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -15,8 +15,8 @@ isort>=5.12.0
 flake8>=6.0.0
 
 # Home Assistant specific 
-homeassistant >= 2026.4.1
-pytest-homeassistant-custom-component >= 0.13.322
+homeassistant >= 2026.4.3
+pytest-homeassistant-custom-component >= 0.13.324
 
 # MQTT testing
 paho-mqtt>=2.1.0; python_version>='3.13'


### PR DESCRIPTION
Der HA-Kompatibilitätstest richtet sich nach pytest-homeassistant-custom-component (PHACC).

- PHACC bleibt die Quelle für die getestete Home-Assistant-Version.
- Der geplante HA-Test läuft wöchentlich auch ohne lokale Dateiänderung.
- README und requirements_test.txt werden über die Dependency-Automation aktualisiert, wenn PHACC eine neue Home-Assistant-Version vorgibt.
